### PR TITLE
Allow res.end() to be used to force-disconnect a client

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This middleware will keep the request stream open indefinitely, pad the initial 
 
 Detailed information on how to setup the browser/client can be found [here][1].
 
+The client can be forced to disconnect by calling res.end().
+
 Installation
 --------
 

--- a/index.js
+++ b/index.js
@@ -27,8 +27,11 @@ function sse(req, res, next) {
     res.sse(':keep-alive\n\n');
   }, 20000);
 
-  // cleanup on close
+  // cleanup on close and finish
   res.on('close', function close() {
+    clearInterval(keepAlive);
+  });
+  res.on('finish', function finish() {
     clearInterval(keepAlive);
   });
 


### PR DESCRIPTION
Clear keep-alive timer on ServerResponse's both close and finish events.
This will allow res.end() to be called if a client should be forced to disconnect, without the keep-alive doing a write() to a closed connection, throwing an unhandled exception.
